### PR TITLE
Update illuminate/routing to allow compatible versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
          "php": ">=5.5.9",
-         "illuminate/routing": "5.4.*"
+         "illuminate/routing": "~5.4"
      },
     "require-dev": {
         "phpunit/phpunit": "~5.7",


### PR DESCRIPTION
As illuminate/routing uses semver, all > 5.4.* should be compatible. That why we update this dependency.